### PR TITLE
Update http_client.rb so custom templates can be uploaded

### DIFF
--- a/lib/logstash/outputs/amazon_es/http_client.rb
+++ b/lib/logstash/outputs/amazon_es/http_client.rb
@@ -360,7 +360,7 @@ module LogStash; module Outputs; class ElasticSearch;
     end
 
     def template_put(name, template)
-      path = "_template/#{name}"
+      path = "/_template/#{name}"
       logger.info("Installing amazon_es template to #{path}")
       @pool.put(path, nil, LogStash::Json.dump(template))
     end


### PR DESCRIPTION
Fixes https://github.com/awslabs/logstash-output-amazon_es/issues/101

Below config would not work otherwise. It would fail with similar results. Once the / was added it would apply.

```erb
output {
  amazon_es {
    hosts => ["redacted.us-west-2.es.amazonaws.com"]
    region => "us-west-2"
    index => "logstash-humans-%{+YYYY.MM.dd}"
template => "/usr/share/logstash/vendor/bundle/jruby/2.3.0/gems/logstash-output-amazon_es-6.4.0-java/lib/logstash/outputs/amazon_es/elasticsearch-template-es6x.json"
template_overwrite => true
document_type => "_doc"
  }
}
``